### PR TITLE
[cryptofuzz] EverCrypt: clone repo instead of downloading archive

### DIFF
--- a/projects/cryptofuzz/Dockerfile
+++ b/projects/cryptofuzz/Dockerfile
@@ -34,6 +34,6 @@ RUN git clone --depth 1 https://github.com/jedisct1/libsodium.git
 RUN git clone --depth 1 https://github.com/weidai11/cryptopp/
 RUN git clone --depth 1 https://dev.gnupg.org/source/libgcrypt.git
 RUN wget https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.36.tar.bz2
-RUN wget https://github.com/project-everest/hacl-star/releases/download/evercrypt-v0.1alpha1/hacl-star-evercrypt-v0.1alpha1-bugfix.tar.gz
+RUN git clone --depth 1 -b oss-fuzz https://github.com/project-everest/hacl-star evercrypt
 
 COPY build.sh $SRC/

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -100,10 +100,6 @@ fi
 if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile EverCrypt (with assembly)
-    cd $SRC/
-    tar zxvf hacl-star-evercrypt-v0.1alpha1-bugfix.tar.gz
-    mv hacl-star-evercrypt-v0.1alpha1 evercrypt
-
     cd $SRC/evercrypt/dist/generic
     make -j$(nproc) || true
 
@@ -248,14 +244,14 @@ then
 fi
 
 ##############################################################################
-# Compile BoringSSL (with assembly)
+# Compile BoringSSL (without assembly)
 cd $SRC/boringssl
 rm -rf build ; mkdir build
 cd build
 cmake -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_C_FLAGS="$CFLAGS" -DBORINGSSL_ALLOW_CXX_RUNTIME=1 -DOPENSSL_NO_ASM=1 ..
 make -j$(nproc) crypto
 
-# Compile Cryptofuzz BoringSSL (with assembly) module
+# Compile Cryptofuzz BoringSSL (without assembly) module
 cd $SRC/cryptofuzz/modules/openssl
 OPENSSL_INCLUDE_PATH="$SRC/boringssl/include" OPENSSL_LIBCRYPTO_A_PATH="$SRC/boringssl/build/crypto/libcrypto.a" CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_BORINGSSL" make -B
 

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -100,11 +100,11 @@ fi
 if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile EverCrypt (with assembly)
-    cd $SRC/evercrypt/dist/generic
+    cd $SRC/evercrypt/dist/portable
     make -j$(nproc) || true
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"
-    export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/generic/libevercrypt.a"
+    export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/portable/libevercrypt.a"
     export KREMLIN_A_PATH="$SRC/evercrypt/dist/kremlin/kremlib/dist/minimal/*.o"
     export EVERCRYPT_INCLUDE_PATH="$SRC/evercrypt/dist"
     export KREMLIN_INCLUDE_PATH="$SRC/evercrypt/dist/kremlin/include"

--- a/projects/cryptofuzz/build.sh
+++ b/projects/cryptofuzz/build.sh
@@ -100,8 +100,9 @@ fi
 if [[ $CFLAGS != *sanitize=memory* ]]
 then
     # Compile EverCrypt (with assembly)
-    cd $SRC/evercrypt/dist/portable
-    make -j$(nproc) || true
+    cd $SRC/evercrypt/dist
+    make -C portable -j$(npro) libevercrypt.a
+    make -C kremlin/kremlib/dist/minimal -j$(nproc)
 
     export CXXFLAGS="$CXXFLAGS -DCRYPTOFUZZ_EVERCRYPT"
     export EVERCRYPT_A_PATH="$SRC/evercrypt/dist/portable/libevercrypt.a"


### PR DESCRIPTION
This will let OSS-Fuzz track revisions and identify fixes in the repository. 
It also lets us push updates and fixes without bothering you and have a commit hash to refer to in reports.